### PR TITLE
✨ Add maintenance mode

### DIFF
--- a/src/main/java/net/aniruddha/remind/Bot.java
+++ b/src/main/java/net/aniruddha/remind/Bot.java
@@ -32,6 +32,8 @@ public class Bot {
 					if (!author.isBot() && command[0].toString().equals(System.getenv("prefix"))) {
 						if (command.length < 2)
 							defaultWrongCommandMessage(message);
+						else if (System.getenv("maintenance").equals("enabled"))
+							maintenanceModeMessage(message);
 						else {
 							if (command[1].toString().equals("help"))
 								help.displayHelp(message);
@@ -55,6 +57,14 @@ public class Bot {
 		message.getChannel().subscribe(channel -> {
 			channel.createMessage("I am sorry, but I could not understand what you wanted me to do. Please run `"
 					+ System.getenv("prefix") + " help` to see a list of all valid commands.").subscribe();
+		});
+	}
+
+	public static void maintenanceModeMessage(Message message) {
+		message.getChannel().subscribe(channel -> {
+			channel.createMessage(
+					"I am so sorry to disappoint you, but I am currently undergoing maintenance. Please re-try after sometime. You can visit https://remind.aniruddha.net/status to know more.")
+					.subscribe();
 		});
 	}
 }


### PR DESCRIPTION
## Summary
A maintenance mode is added that shows a message to the user that the bot is undergoing maintenance. This maintenance mode is controlled using an environment variable.

## Description
Sometimes it becomes necessary to stop the bot from the production environment and do some changes in the deployment environment. In case of such an event, if the user wants to do something with the bot, the command will fail without any response emitted to the user. To prevent such a scenario, a Maintenance Mode is being added to the bot.

## Features
- Add a Maintenance Mode that tells the user about the downtime
- The mode can be toggled using an environment variable

## How does it work?
1. Set the environment variable `maintenance` to `enabled` in order to enable the mode.
2. Any other value of the `maintenance` environment variable results in the mode being switched off.

## Screenshots
1. Bot response with environment variable `maintenance` set to `enabled`.
![Screenshot from 2021-05-01 03-52-18](https://user-images.githubusercontent.com/48330897/116759738-b793c900-aa30-11eb-8061-5d7766dbed22.png)

